### PR TITLE
Work with new sydney region

### DIFF
--- a/ec2costs.py
+++ b/ec2costs.py
@@ -2,6 +2,7 @@
 import json
 import urllib2
 import pprint
+import sys
 
 ondemand_costs_url = "http://aws.amazon.com/ec2/pricing/pricing-on-demand-instances.json"
 
@@ -39,17 +40,20 @@ def get_current_ondemand_costs():
 
     for region in data["config"]["regions"]:
         region = dict(region)
-        region_string = ec2_region_map[region["region"]]
-        prices[region_string] = {}
-        for instance in region["instanceTypes"]:
-            inst_type = instance["type"]
-            for size in instance["sizes"]:
-                for values in size["valueColumns"]:
-                    if values["name"] == "linux":
-                        linux_cost = values["prices"]["USD"]
-                    elif values["name"] == "mswin":
-                        win_cost = values["prices"]["USD"]
-                prices[region_string][ec2_type_map[inst_type] + "." + ec2_size_map[size["size"]]] = {"windows": win_cost, "linux": linux_cost}
+        try:
+		region_string = ec2_region_map[region["region"]]
+		prices[region_string] = {}
+		for instance in region["instanceTypes"]:
+		    inst_type = instance["type"]
+		    for size in instance["sizes"]:
+			for values in size["valueColumns"]:
+			    if values["name"] == "linux":
+				linux_cost = values["prices"]["USD"]
+			    elif values["name"] == "mswin":
+				win_cost = values["prices"]["USD"]
+			prices[region_string][ec2_type_map[inst_type] + "." + ec2_size_map[size["size"]]] = {"windows": win_cost, "linux": linux_cost}
+	except:
+                print >> sys.stderr, "WARNING: Amazon added a new region or instance type that we don't know about yet."
 
     return prices
 

--- a/ec2costs.py
+++ b/ec2costs.py
@@ -27,6 +27,7 @@ ec2_region_map = {"apac-sin": "ap-northeast-1",
                 "us-west": "us-west-1",
                 "eu-ireland": "eu-west-1",
                 "apac-tokyo": "ap-southeast-1",
+                "apac-syd": "ap-southeast-2",
                 "us-east": "us-east-1",
                 "us-west-2": "us-west-2",
                 "sa-east-1": "sa-east-1"}

--- a/ec2costs.py
+++ b/ec2costs.py
@@ -41,19 +41,19 @@ def get_current_ondemand_costs():
     for region in data["config"]["regions"]:
         region = dict(region)
         try:
-		region_string = ec2_region_map[region["region"]]
-		prices[region_string] = {}
-		for instance in region["instanceTypes"]:
-		    inst_type = instance["type"]
-		    for size in instance["sizes"]:
-			for values in size["valueColumns"]:
-			    if values["name"] == "linux":
-				linux_cost = values["prices"]["USD"]
-			    elif values["name"] == "mswin":
-				win_cost = values["prices"]["USD"]
-			prices[region_string][ec2_type_map[inst_type] + "." + ec2_size_map[size["size"]]] = {"windows": win_cost, "linux": linux_cost}
-	except:
-                print >> sys.stderr, "WARNING: Amazon added a new region or instance type that we don't know about yet."
+            region_string = ec2_region_map[region["region"]]
+            prices[region_string] = {}
+            for instance in region["instanceTypes"]:
+                inst_type = instance["type"]
+                for size in instance["sizes"]:
+                    for values in size["valueColumns"]:
+                        if values["name"] == "linux":
+                            linux_cost = values["prices"]["USD"]
+                        elif values["name"] == "mswin":
+                            win_cost = values["prices"]["USD"]
+                    prices[region_string][ec2_type_map[inst_type] + "." + ec2_size_map[size["size"]]] = {"windows": win_cost, "linux": linux_cost}
+        except:
+            print >> sys.stderr, "WARNING: Amazon added a new region or instance type that we don't know about yet."
 
     return prices
 


### PR DESCRIPTION
Amazon added a new region in sydney which was causing the script to fail.
Here are two commits that add the new region, as well as add an exception handler to gracefully ignore new regions/instance types you dont yet know about.
